### PR TITLE
feat(entries): category subpath entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ import '@yoyaflow/yoya-ui/ui.css'; // default styles and theme variables
 The source stays plain JavaScript — it runs directly with zero build. Full
 TypeScript experience comes from the type declarations shipped with the
 package; the `types/` directory covers all entry points (root / `core` / `ui` /
+`actions` / `navigation` / `feedback` / `form` / `data-display` / `async` /
 `router` / `echart` / `three` / `devtools`) and includes node classes, factory
 signatures, component state APIs and parent shortcut methods.
 
@@ -475,6 +476,10 @@ npm run build
 yoya.core.js / yoya.core.min.js             core: engine + html + svg + state/i18n/access
 yoya.core.chunk.js / yoya.core.chunk.min.js internal shared chunk (auto-loaded by core/ui/router)
 yoya.ui.js / yoya.ui.min.js                 components + layout + theme
+yoya.actions.js / yoya.navigation.js / yoya.feedback.js (+ .min)
+                                            category increments for bundlers / on-demand pages
+yoya.form.js / yoya.data-display.js / yoya.async.js (+ .min)
+                                            category increments for bundlers / on-demand pages
 yoya.router.js / yoya.router.min.js         router + SSR primitives
 yoya.echart.js / yoya.three.js / yoya.devtools.js (+ .min)
                                             extension increments (bring your own echarts / three)
@@ -489,14 +494,18 @@ yoya.ui-router.umd.js / yoya.ui-router.umd.min.js    window.YoyaUI
 
 # Styles and types
 yoya.ui.css
-types/... (root / core / ui / router / echart / three / devtools)
+types/... (root / core / ui / actions / navigation / feedback / form / data-display / async / router / echart / three / devtools)
 ```
 
 Naming rules: no suffix and `.min` are incremental ESM entries (no core inside; the
 shared chunk loads automatically); `.full` is self-contained (core inlined); `.umd`
 exposes the `window.YoyaUI` global. npm subpaths map to
-`@yoyaflow/yoya-ui/core`, `@yoyaflow/yoya-ui/ui` and `@yoyaflow/yoya-ui/router`;
-SSR primitives come from `./router` — there is no separate `./ssr` subpath.
+`@yoyaflow/yoya-ui/core`, `@yoyaflow/yoya-ui/ui`,
+`@yoyaflow/yoya-ui/actions`, `@yoyaflow/yoya-ui/navigation`,
+`@yoyaflow/yoya-ui/feedback`, `@yoyaflow/yoya-ui/form`,
+`@yoyaflow/yoya-ui/data-display`, `@yoyaflow/yoya-ui/async` and
+`@yoyaflow/yoya-ui/router`; SSR primitives come from `./router` — there is no
+separate `./ssr` subpath.
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -296,7 +296,8 @@ import '@yoyaflow/yoya-ui/ui.css'; // 默认样式与主题变量
 
 源码保持纯 JavaScript——零构建直接运行。完整 TypeScript 体验来自随包发布的
 类型声明；`types/` 目录覆盖全部入口（root / `core` / `ui` / `router` /
-`echart` / `three` / `devtools`），包含节点类、工厂签名、组件状态 API 与父节点快捷方法。
+`actions` / `navigation` / `feedback` / `form` / `data-display` / `async` /
+`router` / `echart` / `three` / `devtools`），包含节点类、工厂签名、组件状态 API 与父节点快捷方法。
 
 ```ts
 import { div, vButton, vCard, toast } from '@yoyaflow/yoya-ui';
@@ -438,6 +439,10 @@ npm run build
 yoya.core.js / yoya.core.min.js             核心：引擎 + html + svg + state/i18n/access
 yoya.core.chunk.js / yoya.core.chunk.min.js 内部共享块（core/ui/router 自动加载）
 yoya.ui.js / yoya.ui.min.js                 组件 + layout + theme
+yoya.actions.js / yoya.navigation.js / yoya.feedback.js（+ .min）
+                                            分类增量（供打包器 / 按需页面）
+yoya.form.js / yoya.data-display.js / yoya.async.js（+ .min）
+                                            分类增量（供打包器 / 按需页面）
 yoya.router.js / yoya.router.min.js         router + SSR 原语
 yoya.echart.js / yoya.three.js / yoya.devtools.js（+ .min）
                                             扩展增量（自行引入 echarts / three）
@@ -452,12 +457,15 @@ yoya.ui-router.umd.js / yoya.ui-router.umd.min.js    window.YoyaUI
 
 # 样式与类型
 yoya.ui.css
-types/...（root / core / ui / router / echart / three / devtools）
+types/...（root / core / ui / actions / navigation / feedback / form / data-display / async / router / echart / three / devtools）
 ```
 
 命名规则：无后缀与 `.min` 是 ESM 增量入口（不含 core，运行时会自动加载共享
 块）；`.full` 是自包含文件（core 已内联）；`.umd` 提供 `window.YoyaUI` 全局。
 npm 子路径对应 `@yoyaflow/yoya-ui/core`、`@yoyaflow/yoya-ui/ui`、
+`@yoyaflow/yoya-ui/actions`、`@yoyaflow/yoya-ui/navigation`、
+`@yoyaflow/yoya-ui/feedback`、`@yoyaflow/yoya-ui/form`、
+`@yoyaflow/yoya-ui/data-display`、`@yoyaflow/yoya-ui/async` 与
 `@yoyaflow/yoya-ui/router`；SSR 渲染原语从 `./router` 导入，不再单独提供
 `./ssr` 子路径。
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,30 @@
       "types": "./types/yoya.ui.d.ts",
       "import": "./dist/yoya.ui.js"
     },
+    "./actions": {
+      "types": "./types/yoya.actions.d.ts",
+      "import": "./dist/yoya.actions.js"
+    },
+    "./navigation": {
+      "types": "./types/yoya.navigation.d.ts",
+      "import": "./dist/yoya.navigation.js"
+    },
+    "./feedback": {
+      "types": "./types/yoya.feedback.d.ts",
+      "import": "./dist/yoya.feedback.js"
+    },
+    "./form": {
+      "types": "./types/yoya.form.d.ts",
+      "import": "./dist/yoya.form.js"
+    },
+    "./data-display": {
+      "types": "./types/yoya.data-display.d.ts",
+      "import": "./dist/yoya.data-display.js"
+    },
+    "./async": {
+      "types": "./types/yoya.async.d.ts",
+      "import": "./dist/yoya.async.js"
+    },
     "./router": {
       "types": "./types/yoya.router.d.ts",
       "import": "./dist/yoya.router.js"

--- a/scripts/build-entries.mjs
+++ b/scripts/build-entries.mjs
@@ -4,6 +4,12 @@ import { rolldown } from 'rolldown';
 const SHARED_INPUTS = {
   core: 'src/yoya.core.js',
   ui: 'src/yoya.ui.js',
+  actions: 'src/yoya.actions.js',
+  navigation: 'src/yoya.navigation.js',
+  feedback: 'src/yoya.feedback.js',
+  form: 'src/yoya.form.js',
+  'data-display': 'src/yoya.data-display.js',
+  async: 'src/yoya.async.js',
   router: 'src/yoya.router.js',
   echart: 'src/yoya.echart.js',
   three: 'src/yoya.three.js',

--- a/src/structure.test.js
+++ b/src/structure.test.js
@@ -89,6 +89,12 @@ describe('foundation module structure', () => {
     expect(existsInSrc('./yoya.core.js')).toBe(true);
     expect(existsInSrc('./yoya.ui.js')).toBe(true);
     expect(existsInSrc('./yoya.ui.css')).toBe(true);
+    expect(existsInSrc('./yoya.actions.js')).toBe(true);
+    expect(existsInSrc('./yoya.navigation.js')).toBe(true);
+    expect(existsInSrc('./yoya.feedback.js')).toBe(true);
+    expect(existsInSrc('./yoya.form.js')).toBe(true);
+    expect(existsInSrc('./yoya.data-display.js')).toBe(true);
+    expect(existsInSrc('./yoya.async.js')).toBe(true);
 
     expect(existsInSrc('./chart.js')).toBe(false);
     expect(existsInSrc('./chart.test.js')).toBe(false);
@@ -131,6 +137,12 @@ describe('foundation module structure', () => {
     const components = await importFromSrc('./components/index.js');
     const coreEntry = await importFromSrc('./yoya.core.js');
     const uiEntry = await importFromSrc('./yoya.ui.js');
+    const actionsEntry = await importFromSrc('./yoya.actions.js');
+    const navigationEntry = await importFromSrc('./yoya.navigation.js');
+    const feedbackEntry = await importFromSrc('./yoya.feedback.js');
+    const formEntry = await importFromSrc('./yoya.form.js');
+    const dataDisplayEntry = await importFromSrc('./yoya.data-display.js');
+    const asyncEntry = await importFromSrc('./yoya.async.js');
     const routerEntry = await importFromSrc('./yoya.router.js');
     const echartEntry = await importFromSrc('./yoya.echart.js');
     const threeEntry = await importFromSrc('./yoya.three.js');
@@ -267,6 +279,19 @@ describe('foundation module structure', () => {
     expect(uiEntry.vDynamicLoader).toBe(asyncViews.vDynamicLoader);
     expect(uiEntry.vUpload).toBe(form.vUpload);
     expect(uiEntry.vRate).toBe(form.vRate);
+    expect(actionsEntry.vButton).toBe(actions.vButton);
+    expect(actionsEntry.vForm).toBeUndefined();
+    expect(actionsEntry.flex).toBeUndefined();
+    expect(navigationEntry.vMenu).toBe(navigation.vMenu);
+    expect(navigationEntry.vButton).toBeUndefined();
+    expect(feedbackEntry.toast).toBe(feedback.toast);
+    expect(feedbackEntry.vForm).toBeUndefined();
+    expect(formEntry.vForm).toBe(form.vForm);
+    expect(formEntry.vButton).toBeUndefined();
+    expect(dataDisplayEntry.vTable).toBe(dataDisplay.vTable);
+    expect(dataDisplayEntry.vForm).toBeUndefined();
+    expect(asyncEntry.vDynamicLoader).toBe(asyncViews.vDynamicLoader);
+    expect(asyncEntry.vTable).toBeUndefined();
     expect(echartEntry.vEchart).toBeTypeOf('function');
     expect(echartEntry.VEchart).toBeTypeOf('function');
     expect(threeEntry.vThree).toBeTypeOf('function');

--- a/src/yoya.actions.js
+++ b/src/yoya.actions.js
@@ -1,0 +1,3 @@
+// 增量 actions 入口：button / buttons / context-menu / dropdown 等操作类组件。
+// core 由 yoya.core.js 提供；其余类目按需从各自子路径导入。
+export * from './actions/index.js';

--- a/src/yoya.async.js
+++ b/src/yoya.async.js
@@ -1,0 +1,3 @@
+// 增量 async 入口：dynamic-loader / lazy-image / skeleton 等异步类组件。
+// core 由 yoya.core.js 提供；其余类目按需从各自子路径导入。
+export * from './async/index.js';

--- a/src/yoya.data-display.js
+++ b/src/yoya.data-display.js
@@ -1,0 +1,3 @@
+// 增量 data-display 入口：table / tree / badge / pagination / chart 等数据展示组件。
+// core 由 yoya.core.js 提供；其余类目按需从各自子路径导入。
+export * from './data-display/index.js';

--- a/src/yoya.feedback.js
+++ b/src/yoya.feedback.js
@@ -1,0 +1,3 @@
+// 增量 feedback 入口：dialog / message / tooltip / confirm 等反馈类组件。
+// core 由 yoya.core.js 提供；其余类目按需从各自子路径导入。
+export * from './feedback/index.js';

--- a/src/yoya.form.js
+++ b/src/yoya.form.js
@@ -1,0 +1,3 @@
+// 增量 form 入口：input / select / checkbox / radio / upload 等表单控件。
+// core 由 yoya.core.js 提供；其余类目按需从各自子路径导入。
+export * from './form/index.js';

--- a/src/yoya.navigation.js
+++ b/src/yoya.navigation.js
@@ -1,0 +1,3 @@
+// 增量 navigation 入口：anchor / breadcrumb / menu / steps / tabs 等导航类组件。
+// core 由 yoya.core.js 提供；其余类目按需从各自子路径导入。
+export * from './navigation/index.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,12 @@
     "paths": {
       "yoya-ui": ["./types/index.d.ts"],
       "yoya-ui/core": ["./types/yoya.core.d.ts"],
+      "yoya-ui/actions": ["./types/yoya.actions.d.ts"],
+      "yoya-ui/navigation": ["./types/yoya.navigation.d.ts"],
+      "yoya-ui/feedback": ["./types/yoya.feedback.d.ts"],
+      "yoya-ui/form": ["./types/yoya.form.d.ts"],
+      "yoya-ui/data-display": ["./types/yoya.data-display.d.ts"],
+      "yoya-ui/async": ["./types/yoya.async.d.ts"],
       "yoya-ui/devtools": ["./types/yoya.devtools.d.ts"],
       "yoya-ui/echart": ["./types/yoya.echart.d.ts"],
       "yoya-ui/three": ["./types/yoya.three.d.ts"],

--- a/types/tests/consumer.ts
+++ b/types/tests/consumer.ts
@@ -27,6 +27,52 @@ import {
   SearchOutlined
 } from 'yoya-ui';
 import { ElementNode, vStateNode } from 'yoya-ui/core';
+import {
+  VButton as ActionsVButton,
+  vButton as actionsVButton,
+  vFloatButton as actionsVFloatButton
+} from 'yoya-ui/actions';
+import {
+  VBreadcrumb as NavigationVBreadcrumb,
+  VMenu as NavigationVMenu,
+  VTabs as NavigationVTabs,
+  vBreadcrumb as navigationVBreadcrumb,
+  vMenu as navigationVMenu,
+  vTabs as navigationVTabs
+} from 'yoya-ui/navigation';
+import {
+  VDialog as FeedbackVDialog,
+  VMessage as FeedbackVMessage,
+  VTooltip as FeedbackVTooltip,
+  toast as feedbackToast,
+  vDialog as feedbackVDialog,
+  vMessage as feedbackVMessage,
+  vTooltip as feedbackVTooltip
+} from 'yoya-ui/feedback';
+import {
+  VForm as FormVForm,
+  VInput as FormVInput,
+  VSelect as FormVSelect,
+  vCheckbox as formVCheckbox,
+  vForm as formVForm,
+  vInput as formVInput,
+  vRate as formVRate,
+  vSelect as formVSelect,
+  vUpload as formVUpload
+} from 'yoya-ui/form';
+import {
+  VBadge as DisplayVBadge,
+  VTable as DisplayVTable,
+  vBadge as displayVBadge,
+  vPagination as displayVPagination,
+  vTable as displayVTable,
+  vTree as displayVTree
+} from 'yoya-ui/data-display';
+import {
+  vDynamicLoader as asyncVDynamicLoader,
+  vLazyImage as asyncVLazyImage,
+  vSkeleton as asyncVSkeleton
+} from 'yoya-ui/async';
 import { vEchart } from 'yoya-ui/echart';
 import { vThree } from 'yoya-ui/three';
 import { hydrate, mount, parseState, renderToString as ssrRender } from 'yoya-ui/router';
@@ -201,3 +247,39 @@ void layout;
 void counter;
 void ssrRender;
 void i18n;
+
+// Category subpath entries resolve to the same component contracts.
+void ActionsVButton;
+void actionsVButton;
+void actionsVFloatButton;
+void NavigationVBreadcrumb;
+void NavigationVMenu;
+void NavigationVTabs;
+void navigationVBreadcrumb;
+void navigationVMenu;
+void navigationVTabs;
+void FeedbackVDialog;
+void FeedbackVMessage;
+void FeedbackVTooltip;
+void feedbackToast;
+void feedbackVDialog;
+void feedbackVMessage;
+void feedbackVTooltip;
+void FormVForm;
+void FormVInput;
+void FormVSelect;
+void formVCheckbox;
+void formVForm;
+void formVInput;
+void formVRate;
+void formVSelect;
+void formVUpload;
+void DisplayVBadge;
+void DisplayVTable;
+void displayVBadge;
+void displayVPagination;
+void displayVTable;
+void displayVTree;
+void asyncVDynamicLoader;
+void asyncVLazyImage;
+void asyncVSkeleton;

--- a/types/yoya.actions.d.ts
+++ b/types/yoya.actions.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Entry types for `yoya-ui/actions`: action components.
+ */
+export * from './actions.js';

--- a/types/yoya.async.d.ts
+++ b/types/yoya.async.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Entry types for `yoya-ui/async`: async-loading components.
+ */
+export * from './async.js';

--- a/types/yoya.data-display.d.ts
+++ b/types/yoya.data-display.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Entry types for `yoya-ui/data-display`: data display components.
+ */
+export * from './data-display.js';

--- a/types/yoya.feedback.d.ts
+++ b/types/yoya.feedback.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Entry types for `yoya-ui/feedback`: feedback components.
+ */
+export * from './feedback.js';

--- a/types/yoya.form.d.ts
+++ b/types/yoya.form.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Entry types for `yoya-ui/form`: form controls.
+ */
+export * from './form.js';

--- a/types/yoya.navigation.d.ts
+++ b/types/yoya.navigation.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Entry types for `yoya-ui/navigation`: navigation components.
+ */
+export * from './navigation.js';


### PR DESCRIPTION
M2 roadmap first item: category subpath entries for bundler/tree-shaking consumption.
- New incremental ESM artifacts: yoya.actions / navigation / feedback / form / data-display / async (+ .min).
- package.json exports + per-entry d.ts + tsconfig paths + consumer type tests.
- Structure tests assert entry identity and cross-category isolation.

Local checks: lint, format, typecheck, 902 tests, build all green.